### PR TITLE
New/crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Yuya <yuya.maemichi@gmail.com>"]
 
 [dependencies]
+rand = "0.3"

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
     - rustup install stable
   post:
     # https://github.com/rust-lang/cargo/issues/3900
-    - sed -i 's/github/git-non-exist-hub/g' ~/.gitconfig
+    - sed -i 's/github/git-non-exist-hub/g' $HOME/.gitconfig
 
 compile:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ dependencies:
       hash cargo 2>/dev/null ||
       curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
     - rustup install stable
-  post:
     # https://github.com/rust-lang/cargo/issues/3900
     - sed -i 's/github/git-non-exist-hub/g' $HOME/.gitconfig
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,9 @@ dependencies:
       hash cargo 2>/dev/null ||
       curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
     - rustup install stable
+  post:
+    # https://github.com/rust-lang/cargo/issues/3900
+    - sed -i 's/github/git-non-exist-hub/g' ~/.gitconfig
 
 compile:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,8 @@ dependencies:
     - rustup install stable
     # https://github.com/rust-lang/cargo/issues/3900
     - sed -i 's/github/git-non-exist-hub/g' $HOME/.gitconfig
+  override:
+    - cargo update
 
 compile:
   override:


### PR DESCRIPTION
crateを使うときは、例の#3900のIssueを解消する必要がある。
要はCircleCIのせい

# 希望
- 依存先のインストールをビルドと分離したい (まだ無理)。
- コンパイル時に毎度ダウンロードされてしまう。